### PR TITLE
Double backslash escaping in Windows global schema

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -6,6 +6,7 @@
 /* eslint-disable max-lines */
 import fs from 'node:fs';
 import path from 'node:path';
+import os from 'os';
 /* ·········································································· */
 import yaml, { isNode, LineCounter } from 'yaml';
 import type { Document } from 'yaml';
@@ -202,7 +203,11 @@ function validateFrontmatter(
             globSchemaAssocs.forEach((mdFilePath) => {
               if (typeof mdFilePath === 'string') {
                 /* Remove appended `./` or `/` */
-                const mdPathCleaned = path.join(mdFilePath);
+                let mdPathCleaned = path.join(mdFilePath);
+                
+                if (os.platform() === 'win32') {
+                  mdPathCleaned = mdPathCleaned.replaceAll('\\', '\\\\');
+                }
 
                 const globber = globToRegExp(mdPathCleaned);
                 if (globber.test(vFile.path)) {


### PR DESCRIPTION
Fix for #12 

globber.test(vFile.path) returned false in Windows systems. It's because Windows uses \ as a directory separator. I found that adding an additional "\\" before making a Regex fixes the issue. Windows doesn't allow for \ in filenames, so hopefully, this should be enough.

I've tested the demo and some of my other tests and now it works as expected. This PR shouldn't affect systems other than Windows.

Thanks